### PR TITLE
Alternate cfg pattern

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ module = Pybind11Extension(
 )
 
 setuptools.setup(name="alephzero",
-                 version="0.3.17",
+                 version="0.3.18",
                  description="TODO: description",
                  author="Leonid Shamis",
                  author_email="leonid.shamis@gmail.com",

--- a/src/a0/cfg.py
+++ b/src/a0/cfg.py
@@ -100,3 +100,25 @@ def update_configs():
             if tid in obj:
                 del obj[tid]
         cfg.registry = next_reg
+
+
+class cfg2:
+
+    def __init__(self, topic, jptr=None, type_=None):
+        self._cfg_reader = Cfg(topic)
+        self._jptr = jptr
+        self._type = type_
+
+    def get(self):
+        cfg_val = json.loads(self._cfg_reader.read().payload.decode())
+        if self._jptr:
+            cfg_val = jsonpointer.resolve_pointer(cfg_val, self._jptr)
+
+        if not self._type:
+            return cfg_val
+        elif type(cfg_val) == dict:
+            return cfg_val if self._type == dict else self._type(**cfg_val)
+        elif type(cfg_val) == list:
+            return cfg_val if self._type == list else self._type(*cfg_val)
+        else:
+            return self._type(cfg_val)


### PR DESCRIPTION
Alternate `cfg` implementation with much less magic.

Previously, `cfg` was an object wrapper that would masquerade as the requested type in almost every way. The two major exceptions was 1) `type(obj)` would not match the underlying type, and 2) C-bindings were not fooled.
The masquerading objects were hooked and updates when the user calls `a0.update_configs()`

New `cfg2` has the same signature, but returns a non-masquerading object that has an explicit `get()` method. `get()` returns a true object of the requested type, not one that updates under the hood.
`get()` always returns the most recent version. No need for an update call.

Example usage here:
```py
bar = a0.cfg2("topic", "/bar", int)
assert bar.get() == 3
```

Ideal transition plan:
* This new pattern is called `cfg2`
* Once this lands, we can update users from `cfg` to `cfg2`
* When no users of the old `cfg` exists, alias `cfg==cfg2`
* Update users from `cfg2` to `cfg`
* Remove `cfg2`
We'll see how well that turns out.